### PR TITLE
Update composer.json to newer releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "illuminate/support": "5.8|6.0|6.1|6.2|6.3|6.4",
-        "illuminate/view": "5.8|6.0|6.1|6.2|6.3|6.4"
+        "illuminate/support": "^5.8 || ^6.0",
+        "illuminate/view": "^5.8 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.2",


### PR DESCRIPTION
The constraint `^5.8 || ^6.0` will allow installation with any version 6 release of Laravel/illuminate.